### PR TITLE
Content of target page renders with Neos 2.0

### DIFF
--- a/Classes/MOC/NotFound/ViewHelpers/RequestViewHelper.php
+++ b/Classes/MOC/NotFound/ViewHelpers/RequestViewHelper.php
@@ -53,6 +53,7 @@ class RequestViewHelper extends AbstractViewHelper {
 	/**
 	 * @param string $path
 	 * @return string
+	 * @throws \Exception
 	 */
 	public function render($path = NULL) {
 		/** @var RequestHandler $activeRequestHandler */

--- a/Resources/Private/Templates/404.html
+++ b/Resources/Private/Templates/404.html
@@ -1,2 +1,3 @@
-{namespace notFound=MOC\NotFound\ViewHelpers}
-<notFound:request path="{f:if(condition: path, then: path, else: '404')}" />
+{namespace notfound=MOC\NotFound\ViewHelpers}
+<f:format.raw><notfound:request path="{f:if(condition: path, then: path, else: '404')}" /></f:format.raw>
+


### PR DESCRIPTION
- Previously the viewhelper was not resolved due to the camelcase namespace
- Content of target page has to be formatted raw
