### PR TITLE
BUGFIX: Fix wrong detection of dimensions prefix

### DIFF
--- a/Classes/MOC/NotFound/ViewHelpers/RequestViewHelper.php
+++ b/Classes/MOC/NotFound/ViewHelpers/RequestViewHelper.php
@@ -134,7 +134,7 @@ class RequestViewHelper extends AbstractViewHelper {
 				}
 			}
 		} else {
-			if (count($firstUriPartExploded) === count($dimensionPresets)) {
+			if (count($firstUriPartExploded) !== count($dimensionPresets)) {
 				return;
 			}
 			foreach ($dimensionPresets as $dimensionName => $dimensionPreset) {


### PR DESCRIPTION
This fixes a simple error when comparing the count of dimension presets
against the number of exploded parts of the first URI path segment.

Fixes #8
