### PR TITLE
BUGFIX: Gracefully handle URLs without (correct) dimensions

### DIFF
--- a/Classes/MOC/NotFound/ViewHelpers/RequestViewHelper.php
+++ b/Classes/MOC/NotFound/ViewHelpers/RequestViewHelper.php
@@ -135,6 +135,17 @@ class RequestViewHelper extends AbstractViewHelper {
 			}
 		} else {
 			if (count($firstUriPartExploded) !== count($dimensionPresets)) {
+				$dimensionValues = [];
+
+				foreach ($dimensionPresets as $dimensionName => $dimensionPreset) {
+					$dimensionValues[] = $dimensionPreset['default'];
+				}
+				
+				$pathDefaultDimensionsPrefix = implode('_', $dimensionValues);
+				
+				// Add default dimensions in front of the path
+				$path = $pathDefaultDimensionsPrefix . '/' . $path;
+				
 				return;
 			}
 			foreach ($dimensionPresets as $dimensionName => $dimensionPreset) {

--- a/Classes/MOC/NotFound/ViewHelpers/RequestViewHelper.php
+++ b/Classes/MOC/NotFound/ViewHelpers/RequestViewHelper.php
@@ -142,6 +142,7 @@ class RequestViewHelper extends AbstractViewHelper {
 				$uriSegment = array_shift($firstUriPartExploded);
 				$preset = $this->contentDimensionPresetSource->findPresetByUriSegment($dimensionName, $uriSegment);
 				if ($preset === null) {
+					$this->appendDefaultDimensionPresetUriSegments($dimensionPresets, $path);
 					return;
 				}
 			}

--- a/Classes/MOC/NotFound/ViewHelpers/RequestViewHelper.php
+++ b/Classes/MOC/NotFound/ViewHelpers/RequestViewHelper.php
@@ -156,7 +156,7 @@ class RequestViewHelper extends AbstractViewHelper {
 	 * @param string $path
 	 * @return void
 	 */
-	protected function appendDefaultDimensionPresetUriSegments($dimensionPresets, &$path) {
+	protected function appendDefaultDimensionPresetUriSegments(array $dimensionPresets, &$path) {
 		$defaultDimensionPresetUriSegments = [];
 		foreach ($dimensionPresets as $dimensionName => $dimensionPreset) {
 			$defaultDimensionPresetUriSegments[] = $dimensionPreset['presets'][$dimensionPreset['defaultPreset']]['uriSegment'];

--- a/Classes/MOC/NotFound/ViewHelpers/RequestViewHelper.php
+++ b/Classes/MOC/NotFound/ViewHelpers/RequestViewHelper.php
@@ -135,17 +135,7 @@ class RequestViewHelper extends AbstractViewHelper {
 			}
 		} else {
 			if (count($firstUriPartExploded) !== count($dimensionPresets)) {
-				$dimensionValues = [];
-
-				foreach ($dimensionPresets as $dimensionName => $dimensionPreset) {
-					$dimensionValues[] = $dimensionPreset['default'];
-				}
-				
-				$pathDefaultDimensionsPrefix = implode('_', $dimensionValues);
-				
-				// Add default dimensions in front of the path
-				$path = $pathDefaultDimensionsPrefix . '/' . $path;
-				
+				$this->appendDefaultDimensionPresetUriSegments($dimensionPresets, $path);
 				return;
 			}
 			foreach ($dimensionPresets as $dimensionName => $dimensionPreset) {
@@ -160,4 +150,16 @@ class RequestViewHelper extends AbstractViewHelper {
 		$path = $matches['firstUriPart'] . '/' . $path;
 	}
 
+	/**
+	 * @param array $dimensionPresets
+	 * @param string $path
+	 * @return void
+	 */
+	protected function appendDefaultDimensionPresetUriSegments($dimensionPresets, &$path) {
+		$defaultDimensionPresetUriSegments = [];
+		foreach ($dimensionPresets as $dimensionName => $dimensionPreset) {
+			$defaultDimensionPresetUriSegments[] = $dimensionPreset['presets'][$dimensionPreset['defaultPreset']]['uriSegment'];
+		}
+		$path = implode('_', $defaultDimensionPresetUriSegments) . '/' . $path;
+	}
 }


### PR DESCRIPTION
If `supportEmptySegmentsForDimensions` is set to `false` (as needed for non-unique dimension values, e.g. `country=de` and `language=de` which then is `de_de`), any URL having a path but lacking (valid) dimensions will lead to an exception:

- http://site.dev/ -> works (shows document in default dimensions)
- http://site.dev/de_de/existing/document -> works (shows document)
- http://site.dev/de_de/missing/document -> works (shows 404)
- http://site.dev/existing/document -> breaks
- http://site.dev/missing/document -> breaks
- http://site.dev/de/existing/document -> breaks
- http://site.dev/foo_bar/missing/document -> breaks

The cases above saying "breaks" show an exception which says:

```
Exception #1426446160: Uri with path "http://site.dev/404" could not be found.

14 MOC\NotFound\ViewHelpers\RequestViewHelper_Original::render("404")
…
```

With this fix the default dimension values will be put before the `$path` variable, the result is valid and the default 404 `uriPathSegment` will be displayed.
