### PR TITLE
TASK: Neos 3.3 compatibility

### DIFF
--- a/Classes/ViewHelpers/RequestViewHelper.php
+++ b/Classes/ViewHelpers/RequestViewHelper.php
@@ -10,6 +10,8 @@ use Neos\Flow\Http\Response;
 use Neos\Flow\Http\Uri;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\Dispatcher;
+use Neos\Flow\Mvc\Routing\Dto\RouteContext;
+use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
 use Neos\Flow\Mvc\Routing\Router;
 use Neos\Flow\Security\Context as SecurityContext;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
@@ -86,7 +88,8 @@ class RequestViewHelper extends AbstractViewHelper
         $parentHttpRequest = $activeRequestHandler->getHttpRequest();
         $uri = rtrim($parentHttpRequest->getBaseUri(), '/') . '/' . $path;
         $httpRequest = Request::create(new Uri($uri));
-        $matchingRoute = $this->router->route($httpRequest);
+        $routeContext = new RouteContext($httpRequest, RouteParameters::createEmpty());
+        $matchingRoute = $this->router->route($routeContext);
         if (!$matchingRoute) {
             $exception = new \Exception(sprintf('Uri with path "%s" could not be found.', $uri), 1426446160);
             $exceptionHandler = set_exception_handler(null)[0];


### PR DESCRIPTION
This PR adjusts the RequestViewHelper for compatibility with Neos 3.3.

**Technical details:** 
Router::route() is now expecting a RouteContext instead of Request.