### PR TITLE
Set viewClassName explicit to disable Neos internal FusionExceptionView

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -6,6 +6,7 @@ Neos:
           notFoundExceptions:
             matchingStatusCodes: [ 404, 410 ]
             options:
+              viewClassName: Neos\FluidAdaptor\View\TemplateView
               templatePathAndFilename: 'resource://MOC.NotFound/Private/Templates/404.html'
               variables:
                 path: '404.html' # skip suffix if unset


### PR DESCRIPTION
This change will override the configuration in Neos >=4.3 and allow this package to handle notFoundExceptions as before.