### PR TITLE
Fixes "Undeclared arguments"

### DIFF
--- a/Classes/ViewHelpers/RequestViewHelper.php
+++ b/Classes/ViewHelpers/RequestViewHelper.php
@@ -75,13 +75,23 @@ class RequestViewHelper extends AbstractViewHelper
     {
         $this->router->setRoutesConfiguration($this->configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_ROUTES));
     }
+    
+    /**
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     * @api
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('path', 'string', 'Path');
+    }
 
     /**
-     * @param string $path
      * @return string
      * @throws \Exception
      */
-    public function render($path = null)
+    public function render()
     {
         $this->appendFirstUriPartIfValidDimension($path);
         /** @var RequestHandler $activeRequestHandler */


### PR DESCRIPTION
Fixes "Undeclared arguments passed to ViewHelper MOC\NotFound\ViewHelpers\RequestViewHelper: path."

(Please be aware that due to this change I got the 404 page to show up again, but it is used in a very basic Neos website. I unfortunately don't have the knowledge to convert this ViewHelper to the new PSR-7 standard.....)