### PR TITLE
Implement PSR-7 for Neos 5.0 compatibility

### DIFF
--- a/Classes/ViewHelpers/RequestViewHelper.php
+++ b/Classes/ViewHelpers/RequestViewHelper.php
@@ -16,6 +16,7 @@ use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
 use Neos\Flow\Mvc\Routing\Router;
 use Neos\Flow\Security\Context as SecurityContext;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
+use Neos\FluidAdaptor\Core\ViewHelper\Exception as ViewHelperException;
 use Neos\Neos\Domain\Service\ContentDimensionPresetSourceInterface;
 use Neos\Neos\Routing\FrontendNodeRoutePartHandler;
 
@@ -75,16 +76,16 @@ class RequestViewHelper extends AbstractViewHelper
     {
         $this->router->setRoutesConfiguration($this->configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_ROUTES));
     }
-    
+
     /**
      * @return void
-     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     * @throws ViewHelperException
      * @api
      */
     public function initializeArguments()
     {
         parent::initializeArguments();
-        $this->registerArgument('path', 'string', 'Path');
+        $this->registerArgument('path', 'string', 'Path', false, '404');
     }
 
     /**
@@ -93,6 +94,7 @@ class RequestViewHelper extends AbstractViewHelper
      */
     public function render()
     {
+        $path = $this->arguments['path'];
         $this->appendFirstUriPartIfValidDimension($path);
         /** @var RequestHandler $activeRequestHandler */
         $activeRequestHandler = $this->bootstrap->getActiveRequestHandler();

--- a/Resources/Private/Templates/404.html
+++ b/Resources/Private/Templates/404.html
@@ -1,2 +1,2 @@
 {namespace notfound=MOC\NotFound\ViewHelpers}
-<f:format.raw><notfound:request path="{f:if(condition: path, then: path, else: '404')}" /></f:format.raw>
+<f:format.raw><notfound:request path="{path}" /></f:format.raw>

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": "^7.1",
-        "ext-curl": "*",
         "neos/neos": "^4.0 || ^5.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
         }
     ],
     "require": {
-        "neos/neos": ">3.3"
+        "php": "^7.1",
+        "ext-curl": "*",
+        "neos/neos": "^4.0 || ^5.0"
     },
     "autoload": {
         "psr-4": {
@@ -95,7 +97,20 @@
             "Neos.Neos-20161219122512",
             "Neos.Fusion-20161219130100",
             "Neos.Neos-20161220163741",
-            "Neos.Fusion-20170120013047"
+            "Neos.Fusion-20170120013047",
+            "Neos.ContentRepository.Search-20161210231100",
+            "Neos.Neos-20170115114620",
+            "Neos.Flow-20170125103800",
+            "Neos.Seo-20170127154600",
+            "Neos.Flow-20170127183102",
+            "Neos.Fusion-20180211175500",
+            "Neos.Fusion-20180211184832",
+            "Neos.Flow-20180415105700",
+            "Neos.Neos-20180907103800",
+            "Neos.Neos.Ui-20190319094900",
+            "Neos.Flow-20190425144900",
+            "Neos.Flow-20190515215000",
+            "Neos.NodeTypes-20190917101945"
         ]
     }
 }


### PR DESCRIPTION
To be compatible with Neos 5.0 PSR-7 needs to be implemented.

I started adapting the code, but came to find that a simple `$response->getContent()` just returns an empty string. The real content lies in `$response->getComponentParameters()` where there is a
`Neos\Flow\Http\Component\ReplaceHttpResponseComponent` on whose `response` parameter you can `->getBody()->getContents()`.
I'm not familiar with this, so I hope someone else can support here.