### PR TITLE
BUGFIX: Set up site in determined dimension and set up I18n service with the proper locale to also show translations from XLIFF files in correct language.

### DIFF
--- a/Classes/Fusion/Eel/Helper/LocaleHelper.php
+++ b/Classes/Fusion/Eel/Helper/LocaleHelper.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace MOC\NotFound\Fusion\Eel\Helper;
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Eel\ProtectedContextAwareInterface;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\I18n\Locale;
+use Neos\Flow\I18n\Service;
+
+/**
+ * See: https://github.com/neos/neos-development-collection/issues/3190#issuecomment-730361990
+ * Thanks to @kdambekalns
+ *
+ * The LocaleHelper deals with i18n-related things.
+ */
+class LocaleHelper implements ProtectedContextAwareInterface
+{
+    /**
+     * @Flow\Inject
+     * @var Service
+     */
+    protected $i18nService;
+
+    /**
+     * Given a node this tries to set the current locale for the Flow i18n service
+     * from the content dimension "language", if possible.
+     *
+     * The input node is returned as is for chaining, to make sure the operation is
+     * actually evaluated.
+     *
+     * @param NodeInterface $node
+     * @return NodeInterface
+     * @throws \Neos\Flow\I18n\Exception\InvalidLocaleIdentifierException
+     */
+    public function setCurrentFromNode(NodeInterface $node, string $languageDimensionName): NodeInterface
+    {
+        $dimensions = $node->getContext()->getDimensions();
+        if (array_key_exists($languageDimensionName, $dimensions) && $dimensions[$languageDimensionName] !== []) {
+            $currentLocale = new Locale($dimensions[$languageDimensionName][0]);
+            $this->i18nService->getConfiguration()->setCurrentLocale($currentLocale);
+            $this->i18nService->getConfiguration()->setFallbackRule(['strict' => false, 'order' => array_reverse($dimensions[$languageDimensionName])]);
+        }
+
+        return $node;
+    }
+
+    /**
+     * All methods are considered safe
+     *
+     * @param string $methodName
+     * @return boolean
+     */
+    public function allowsCallOfMethod($methodName)
+    {
+        return true;
+    }
+}

--- a/Classes/Fusion/Eel/Helper/LocaleHelper.php
+++ b/Classes/Fusion/Eel/Helper/LocaleHelper.php
@@ -11,7 +11,7 @@ use Neos\Flow\I18n\Service;
 
 /**
  * See: https://github.com/neos/neos-development-collection/issues/3190#issuecomment-730361990
- * Thanks to @kdambekalns
+ * Thanks to kdambekalns
  *
  * The LocaleHelper deals with i18n-related things.
  */

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -2,6 +2,7 @@ Neos:
   Fusion:
     defaultContext:
       NotFound.Context: MOC\NotFound\Fusion\Eel\Helper\ContextHelper
+      NotFound.LocaleHelper: MOC\NotFound\Fusion\Eel\Helper\LocaleHelper
   Neos:
     fusion:
       autoInclude:
@@ -9,3 +10,4 @@ Neos:
 MOC:
   NotFound:
     uriPathSegment: 404
+    languageDimensionName: language

--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ Introduction
 
 Neos CMS package that loads a normal editable page for displaying a 404 error.
 
-Compatible with Neos 4.3 - 5.x 
+Compatible with Neos 8.x 
 
 Supports multiple content dimensions with URI segments and empty segments for default dimensions.
 
 Installation
 ------------
-```composer require "moc/notfound:^4.0"```
+```composer require "moc/notfound"```
 
 Create a page with the URI segment "404" in the root of your site. If using content dimensions with URI segments,
-ensure a page exists in all contexts or through fallbacks.
+ensure a page exists in all contexts or through fallbacks. Per default the package assumes the name of the language dimension as "language". 
 
 Alternatively set the following configuration in ``Settings.yaml``:
 
@@ -28,6 +28,7 @@ Alternatively set the following configuration in ``Settings.yaml``:
 MOC:
   NotFound:
     uriPathSegment: 404
+    languageDimensionName: language
 ```
 
 Note: If you override the configuration in a package's configuration instead of globally, you need to ensure that package is loaded after this package. To do so, add ``"moc/notfound": "*"`` to the package's ``require`` section in it's ``composer.json``.

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -14,6 +14,9 @@ error {
         @position = 'start'
         condition = ${statusCode >= 400 && statusCode < 500 && notfoundDocument}
         renderer = Neos.Fusion:Renderer {
+            languageDimensionName = ${Configuration.setting('MOC.NotFound.languageDimensionName')}
+            i18nServiceToProperLocale = ${NotFound.LocaleHelper.setCurrentFromNode(notfoundDocument, this.languageDimensionName)}
+            @context.site = ${notfoundDocument.context.currentSiteNode}
             @context.node = ${notfoundDocument}
             @context.documentNode = ${notfoundDocument}
             renderPath = '/root'

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -15,7 +15,7 @@ error {
         condition = ${statusCode >= 400 && statusCode < 500 && notfoundDocument}
         renderer = Neos.Fusion:Renderer {
             languageDimensionName = ${Configuration.setting('MOC.NotFound.languageDimensionName')}
-            i18nServiceToProperLocale = ${NotFound.LocaleHelper.setCurrentFromNode(notfoundDocument, this.languageDimensionName)}
+            @context.i18nServiceToProperLocale = ${NotFound.LocaleHelper.setCurrentFromNode(notfoundDocument, this.languageDimensionName)}
             @context.site = ${notfoundDocument.context.currentSiteNode}
             @context.node = ${notfoundDocument}
             @context.documentNode = ${notfoundDocument}

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "neos/neos": ">=4.3"
+        "neos/neos": ">=8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This fixe ensures, that site node is set in correct dimensions. Also it sets the locale of the language dimension as locale for the I18n service.